### PR TITLE
sc-12773 use a more rigid regex for tfvars templating

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Config Catalyst automatically converts static config files in your repos into parameterized templates.
 It's the easiest way to "pay down config tech debt" with a single command.
 
-We :heart: feedback, [bugs](https://github.com/cloudtruth/config-catalyst/issues/new), and [enhancement suggestions](https://github.com/cloudtruth/config-catalyst/issues/new). 
+We :heart: feedback, [bugs](https://github.com/cloudtruth/config-catalyst/issues/new), and [enhancement suggestions](https://github.com/cloudtruth/config-catalyst/issues/new).
 
 We also have a #config-catalyst channel [on our Discord](https://discord.com/invite/eBZXm9Tzr7).
 
@@ -19,7 +19,7 @@ Config Catalyst exists to solve this problem:
 
 >"I need to take this weird network config that Bob (who left five years ago) roughed out by hand and turn it into a crisp little YAML template with parameterized variables."
 
-Static, hard-coded config is a form of "tech debt" many teams want to eliminate, but the "pay it down" process is tedious and time-consuming. Until now. 
+Static, hard-coded config is a form of "tech debt" many teams want to eliminate, but the "pay it down" process is tedious and time-consuming. Until now.
 
 # How it works
 Config Catalyst works off of a local copy of your repo folder structure.

--- a/src/dynamic_importer/api/client.py
+++ b/src/dynamic_importer/api/client.py
@@ -305,7 +305,6 @@ class CTClient:
             environment_id = self.create_environment(environment_name)["id"]
             parameter_id = self.create_parameter(project_name, parameter_name)["id"]
 
-        value = str(value) if isinstance(value, bool) else value
         resp = self._make_request(
             f"projects/{project_id}/parameters/{parameter_id}/values",
             "POST",
@@ -329,7 +328,7 @@ class CTClient:
         environment_id = self.get_environment_id(environment_name)
         parameter_id = self.get_parameter_id(project_name, parameter_name)
 
-        value = str(value) if isinstance(value, bool) else value
+        value = str(value).lower() if isinstance(value, bool) else value
         return self._make_request(
             f"projects/{project_id}/parameters/{parameter_id}/values/{value_id}",
             "PATCH",

--- a/src/dynamic_importer/api/client.py
+++ b/src/dynamic_importer/api/client.py
@@ -305,6 +305,7 @@ class CTClient:
             environment_id = self.create_environment(environment_name)["id"]
             parameter_id = self.create_parameter(project_name, parameter_name)["id"]
 
+        value = str(value).lower() if isinstance(value, bool) else value
         resp = self._make_request(
             f"projects/{project_id}/parameters/{parameter_id}/values",
             "POST",

--- a/src/dynamic_importer/processors/__init__.py
+++ b/src/dynamic_importer/processors/__init__.py
@@ -158,9 +158,10 @@ class BaseProcessor:
             if not hints:
                 obj_type = self.guess_type(obj)
                 param_name = self.path_to_param_name(path)
+                value = str(obj).lower() if obj_type == "boolean" else obj
                 return f"{{{{ cloudtruth.parameters.{param_name} }}}}", {
                     path: {
-                        "values": {env: obj},
+                        "values": {env: value},
                         "param_name": param_name,
                         "type": obj_type,
                         "secret": self.is_param_secret(param_name),

--- a/src/dynamic_importer/processors/tf.py
+++ b/src/dynamic_importer/processors/tf.py
@@ -83,9 +83,12 @@ class TFProcessor(BaseProcessor):
             if set(obj.keys()) >= self.data_keys:
                 if not hints:
                     param_name = self.path_to_param_name(path)
+                    value = (
+                        str(obj["default"]).lower() if obj["type"] == "boolean" else obj
+                    )
                     return f"{{{{ cloudtruth.parameters.{param_name} }}}}", {
                         path: {
-                            "values": {env: obj["default"]},
+                            "values": {env: value},
                             "param_name": param_name,
                             "description": obj.get("description", ""),
                             "type": obj["type"],
@@ -111,9 +114,10 @@ class TFProcessor(BaseProcessor):
             if not hints:
                 obj_type = self.guess_type(obj)
                 param_name = self.path_to_param_name(path)
+                value = str(obj).lower() if obj_type == "boolean" else obj
                 return f"{{{{ cloudtruth.parameters.{param_name} }}}}", {
                     path: {
-                        "values": {env: obj},
+                        "values": {env: value},
                         "param_name": param_name,
                         "type": obj_type,
                         "secret": False,

--- a/src/dynamic_importer/processors/tfvars.py
+++ b/src/dynamic_importer/processors/tfvars.py
@@ -42,8 +42,13 @@ class TFVarsProcessor(BaseProcessor):
         environment = "default"
         if config_data:
             for _, data in config_data.items():
-                value = str(data["values"][environment])
-                reference = rf'{{{{ cloudtruth.parameters.{data["param_name"]} }}}}'
+                source_name = sub(r"_\d+", "", data["param_name"])
+                value = (
+                    rf"({source_name})(\s*=\s*.*){str(data['values'][environment])}(.*)"
+                )
+                reference = (
+                    rf'\1\2{{{{ cloudtruth.parameters.{data["param_name"]} }}}}\3'
+                )
                 template_body = sub(value, reference, template_body)
 
         return template_body


### PR DESCRIPTION
because the hcl python sdk doesn't allow dumping of loaded files, we have to use a regex to generate a template. Greg proved that regex to be too relaxed

also another fix for converting True to true